### PR TITLE
fix type-error in errpoly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,9 +31,6 @@ jobs:
           - os: macOS-latest
             version: '1'
             arch: x64
-          - os: ubuntu-latest
-            version: '1'
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QRDecoders"
 uuid = "d4999880-6331-4276-8b7d-7ee1f305cff8"
 authors = ["rex <1073853456@qq.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/syndrome.jl
+++ b/src/syndrome.jl
@@ -122,7 +122,7 @@ Returns true if the received polynomial has errors. (may go undetected when the 
 haserrors(received::Poly, nsym::Integer) = !iszeropoly(syndrome_polynomial(received, nsym))
 
 """
-    erratalocator_polynomial(errpos::AbstractVector)
+    erratalocator_polynomial(::Type{T}, errpos::AbstractVector)
 
 Compute the erasures/error locator polynomial Λ(x) from the erasures/errors positions.
 """
@@ -380,7 +380,7 @@ function euclidean_decoder!(received::Poly{T}, erasures::AbstractVector, nsym::I
     iszeropoly(sydpoly) && return received
     
     ## erasures locator polynomial Γx
-    Γx = erratalocator_polynomial(erasures)
+    Γx = erratalocator_polynomial(T, erasures)
     xn = Poly(push!(zeros(T, nsym), one(T)))
     
     ## deg(Ω(x))  ≤ ⌊(nsym + length(erasures)) / 2⌋ - 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,9 +60,10 @@ using QRDecoders.Syndrome:
 
 Random polynomial of degree n.
 """
-randpoly(n::Int) = Poly([rand(0:255, n-1)..., rand(1:255)])
-randpoly(range::AbstractVector) = randpoly(rand(range))
-
+randpoly(::Type{T}, n::Int) where T = Poly{T}([rand(0:255, n-1)..., rand(1:255)])
+randpoly(n::Int) = randpoly(UInt8, n)
+randpoly(::Type{T}, range::AbstractVector{Int}) where T = randpoly(T, rand(range))
+randpoly(range::AbstractVector{Int}) = randpoly(UInt8, range)
 eclevels = [Low(), Medium(), Quartile(), High()]
 modes = [Numeric(), Alphanumeric(), Kanji(), Byte(), UTF8()]
 

--- a/test/tst_euclidean.jl
+++ b/test/tst_euclidean.jl
@@ -3,33 +3,33 @@
 @testset "Euclidean division" begin
     ## extended_euclidean_divide(r₁::Poly, r₂::Poly)
     ## Sugiyama_euclidean_divide(r₁::Poly, r₂::Poly, upperdeg::Int)
-    r = randpoly(55) ## common factor of f(x) and g(x)
-    f = r * randpoly(1:200)
-    g = r * randpoly(1:200)
+    r = randpoly(Int, 55) ## common factor of f(x) and g(x)
+    f = r * randpoly(Int, 1:200)
+    g = r * randpoly(Int, 1:200)
     a, b, common = extended_euclidean_divide(f, g)
     @test iszeropoly(a * f + b * g + common)
     @test iszeropoly(f % common) && iszeropoly(g % common)
     a, b, common = Sugiyama_euclidean_divide(f, g, 100)
     @test iszeropoly(a * f + b * g + common)
 
-    f, g = randpoly(rand(1:255)), Poly([0, 0])
+    f, g = randpoly(Int, rand(1:255)), Poly([0, 0])
     a, b, common = extended_euclidean_divide(f, g)
     @test iszeropoly(a * f + b * g + common)
     @test iszeropoly(f % common) && iszeropoly(g % common)
 
-    f, g = Poly([0, 0]), randpoly(rand(1:255))
+    f, g = Poly([0, 0]), randpoly(Int, rand(1:255))
     a, b, common = extended_euclidean_divide(f, g)
     @test iszeropoly(a * f + b * g + common)
     @test iszeropoly(f % common) && iszeropoly(g % common)
 
-    f = randpoly(20:200)
-    g = randpoly(20:200)
+    f = randpoly(Int, 20:200)
+    g = randpoly(Int, 20:200)
     a, b, common = Sugiyama_euclidean_divide(f, g, 20)
     @test iszeropoly(a * f + b * g + common)
 end
 
 @testset "Euclidean decoder -- without erasures" begin
-    rawmsg = randpoly(155)
+    rawmsg = randpoly(Int, 155)
     nsym = 100
     errpos = unique!(rand(0:254, 50)) # error positions
     msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
@@ -41,7 +41,7 @@ end
     @test euclidean_decoder(msg, nsym) == msg
 
     ### odd number of syndromes
-    rawmsg = randpoly(100)
+    rawmsg = randpoly(Int, 100)
     nsym = 155
     errpos = unique!(rand(0:254, 77)) # error positions
     msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
@@ -50,7 +50,7 @@ end
     @test euclidean_decoder(received, nsym) == msg
 
     ### too much errors(detected)
-    rawmsg = randpoly(100)
+    rawmsg = randpoly(Int, 100)
     nsym = 155
     errpos = sample(0:254, 78; replace=false) # error positions
     msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
@@ -74,13 +74,13 @@ end
     ## euclidean_decoder(received::Poly, erasures::AbstractVector, nsym::Int)
 
     ### length of the received message is too long
-    rawmsg = randpoly(100)
+    rawmsg = randpoly(Int, 100)
     nsym = 156
     msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
     @test_throws DomainError euclidean_decoder(msg, nsym)
     
     ### number of erasures exceeds the capacity of RS-Code
-    rawmsg = randpoly(150)
+    rawmsg = randpoly(Int, 150)
     nsym = 50
     msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
     erasures = sample(0:199, 51; replace=false)
@@ -88,7 +88,7 @@ end
 
     ### number of errors within the capacity of RS-Code
     ### 2 * v + ρ = 60 + 40 == nsym
-    rawmsg = randpoly(155)
+    rawmsg = randpoly(Int, 155)
     nsym = 100
     errpos = sample(0:254, 70; replace=false) # error positions
     erasures = errpos[31:70]
@@ -98,13 +98,13 @@ end
     @test euclidean_decoder(received, erasures, nsym) == msg
     ### Γx and Ωx by euclidean_decoder
     sydpoly = syndrome_polynomial(received, nsym)
-    Γx = erratalocator_polynomial(erasures)
+    Γx = erratalocator_polynomial(Int, erasures)
     xn = Poly(push!(zeros(Int, nsym), 1))
     upperdeg = (nsym + length(erasures)) ÷ 2 - 1
     Λx, _, Ωx = Sugiyama_euclidean_divide(sydpoly * Γx, xn, upperdeg)
     Λx *= Γx
     ### Λx and Ωx by direct computation
-    errloc = erratalocator_polynomial(errpos)
+    errloc = erratalocator_polynomial(Int, errpos)
     evlpoly = evaluator_polynomial(sydpoly, errloc, nsym)
     c0 = errloc ÷ Λx
     @test iszeropoly(c0 * Λx + errloc) && iszeropoly(c0 * Ωx + evlpoly)
@@ -114,7 +114,7 @@ end
     @test euclidean_decoder(received, erasures, nsym) == msg
     ### Γx and Ωx by euclidean_decoder
     sydpoly = syndrome_polynomial(received, nsym)
-    Γx = erratalocator_polynomial(erasures)
+    Γx = erratalocator_polynomial(Int, erasures)
     xn = Poly(push!(zeros(Int, nsym), 1))
     upperdeg = (nsym + length(erasures)) ÷ 2 - 1
     Λx, _, Ωx = Sugiyama_euclidean_divide(sydpoly * Γx, xn, upperdeg)
@@ -123,7 +123,7 @@ end
 
     ### errors within the capacity of the RS-Code
     ### 55 + 50 * 2 ≤ 155
-    rawmsg = randpoly(100)
+    rawmsg = randpoly(Int, 100)
     nsym = 155
     errpos = sample(0:254, 105; replace=false) # error positions
     erasures = errpos[51:105]
@@ -133,20 +133,20 @@ end
     @test euclidean_decoder(received, erasures, nsym) == msg
     ### Γx and Ωx by euclidean_decoder
     sydpoly = syndrome_polynomial(received, nsym)
-    Γx = erratalocator_polynomial(erasures)
+    Γx = erratalocator_polynomial(Int, erasures)
     xn = Poly(push!(zeros(Int, nsym), 1))
     upperdeg = (nsym + length(erasures)) ÷ 2 - 1
     Λx, _, Ωx = Sugiyama_euclidean_divide(sydpoly * Γx, xn, upperdeg)
     Λx *= Γx
     ### Λx and Ωx by direct computation
-    errloc = erratalocator_polynomial(errpos)
+    errloc = erratalocator_polynomial(Int, errpos)
     evlpoly = evaluator_polynomial(sydpoly, errloc, nsym)
     c0 = errloc ÷ Λx
     @test iszeropoly(c0 * Λx + errloc) && iszeropoly(c0 * Ωx + evlpoly)
 
     ### too much errors(detected)
     ### 2 * v + ρ = d + 1
-    rawmsg = randpoly(100)
+    rawmsg = randpoly(Int, 100)
     v, ρ = rand(20:50), rand(20:55)
     nsym = 2 * v + ρ - 1
     errpos = sample(0:(nsym + 100 - 1), nsym + 1; replace=false) # error positions
@@ -168,13 +168,13 @@ end
     @test euclidean_decoder(received, erasures, nsym) == msg
     ### Γx and Ωx by euclidean_decoder
     sydpoly = syndrome_polynomial(received, nsym)
-    Γx = erratalocator_polynomial(erasures)
+    Γx = erratalocator_polynomial(Int, erasures)
     xn = Poly(push!(zeros(Int, nsym), 1))
     upperdeg = (nsym + length(erasures)) ÷ 2 - 1
     Λx, _, Ωx = Sugiyama_euclidean_divide(sydpoly * Γx, xn, upperdeg)
     Λx *= Γx
     ### Λx and Ωx by direct computation
-    errloc = erratalocator_polynomial(errpos)
+    errloc = erratalocator_polynomial(Int, errpos)
     evlpoly = evaluator_polynomial(sydpoly, errloc, nsym)
     c0 = errloc ÷ Λx
     @test iszeropoly(c0 * Λx + errloc) && iszeropoly(c0 * Ωx + evlpoly)

--- a/test/tst_syndrome.jl
+++ b/test/tst_syndrome.jl
@@ -25,7 +25,7 @@
     syd = syndrome_polynomial(msg, n) # syndrome polynomial
     @test syd.coeff == [64, 192, 93, 231, 52, 92, 228, 49, 83, 245]
     @test haserrors(msg, n)
-    errlocpoly = erratalocator_polynomial(UInt8, [0]) # error locator polynomial
+    errlocpoly = erratalocator_polynomial([0]) # error locator polynomial
     evlpoly = evaluator_polynomial(syd, errlocpoly, n) # evaluator polynomial
     xn = Poly{UInt8}(push!(zeros(Int, n), 1)) ## xn = x^n
     @test iszeropoly(evlpoly + syd * errlocpoly % xn)
@@ -240,7 +240,7 @@ end
     errpos = [0, 1]
     received = copy(msg)
     received.coeff[1 .+ errpos] .⊻= [2, 3]
-    errlocpoly = erratalocator_polynomial(UInt8, errpos)
+    errlocpoly = erratalocator_polynomial(errpos) # default UInt8
     sydpoly = syndrome_polynomial(received, nsym)
     Λx = erratalocator_polynomial(sydpoly, nsym; check=true)
     @test !iszeropoly(errlocpoly + Λx)

--- a/test/tst_syndrome.jl
+++ b/test/tst_syndrome.jl
@@ -4,7 +4,7 @@
 @testset "Operators for polynomials" begin
     ## polynomial_eval(p::Poly, x::Int)
     ### take values at 0 and 1
-    p = randpoly(1:255)
+    p = randpoly(Int, 1:255)
     @test polynomial_eval(p, 1) == reduce(⊻, p.coeff)
     @test polynomial_eval(p, 0) == first(p.coeff)
     ### polynomial of degree ≤ 3
@@ -25,21 +25,21 @@
     syd = syndrome_polynomial(msg, n) # syndrome polynomial
     @test syd.coeff == [64, 192, 93, 231, 52, 92, 228, 49, 83, 245]
     @test haserrors(msg, n)
-    errlocpoly = erratalocator_polynomial(UInt8[0]) # error locator polynomial
+    errlocpoly = erratalocator_polynomial(UInt8, [0]) # error locator polynomial
     evlpoly = evaluator_polynomial(syd, errlocpoly, n) # evaluator polynomial
     xn = Poly{UInt8}(push!(zeros(Int, n), 1)) ## xn = x^n
     @test iszeropoly(evlpoly + syd * errlocpoly % xn)
 
-    ## erratalocator_polynomial(errpos::AbstractVector)
+    ## erratalocator_polynomial
     nerr = rand(1:255) # number of errors
     errpos = rand(0:255, nerr)
     polyroots = Int.(gfpow2.(255 .- errpos)) # roots of error locator polynomial are 2 .^ -(errpos)
-    locpoly = erratalocator_polynomial(errpos)
+    locpoly = erratalocator_polynomial(Int, errpos)
     @test all(iszero, polynomial_eval.(Ref(locpoly), polyroots)) && length(locpoly) == nerr + 1
-    @test erratalocator_polynomial(Int[]) == Poly([1])
+    @test erratalocator_polynomial(Int, Int[]) == Poly([1])
 
     ## reducebyHorner(p::Poly, a::Int)
-    p, a = randpoly(2:255), rand(0:255)
+    p, a = randpoly(Int, 2:255), rand(0:255)
     qx = reducebyHorner(p, a)
     qeval = popfirst!(qx.coeff)
     @test qeval == polynomial_eval(p, a)
@@ -58,10 +58,10 @@
 
     ## getpositions(Λx::Poly)
     positions = sort!(unique!(rand(0:254, rand(1:255))))
-    Λx = erratalocator_polynomial(positions)
+    Λx = erratalocator_polynomial(Int, positions)
     @test sort!(getpositions(Λx)) == positions
     positions = collect(0:254)
-    Λx = erratalocator_polynomial(positions)
+    Λx = erratalocator_polynomial(Int, positions)
     @test sort!(getpositions(Λx)) == positions
 end
 
@@ -70,7 +70,7 @@ end
     ## haserrors(msg::Poly, n::Int)
     ### RS-Code can detect up to n errors
     ### message without errors
-    f, n = randpoly(1:127), rand(1:127)
+    f, n = randpoly(Int, 1:127), rand(1:127)
     msg = f << n + geterrcode(f, n)
     @test !haserrors(msg, n)
 
@@ -103,7 +103,7 @@ end
 
     ### random test
     fdeg, n = rand(1:200), 55
-    rawmsg = randpoly(fdeg)
+    rawmsg = randpoly(Int, fdeg)
     msg = rawmsg << n + geterrcode(rawmsg, n)
     ### received message
     errpos = sample(0:(n + fdeg - 1), 55; replace=false)
@@ -114,13 +114,13 @@ end
     ### error exceeds limitation
     n = 10
     errpos = collect(1:11)
-    rawmsg = randpoly(1:20)
+    rawmsg = randpoly(Int, 1:20)
     msg = rawmsg << n + geterrcode(rawmsg, n)
     @test_throws ReedSolomonError fillerasures(msg, errpos, n)
 
     ### no errors
     n = 55
-    rawmsg = randpoly(200)
+    rawmsg = randpoly(Int, 200)
     msg = rawmsg << n + geterrcode(rawmsg, n)
     errpos = unique!(rand(0:254, 55))
     @test fillerasures(msg, errpos, n) == msg
@@ -132,7 +132,7 @@ end
     ## berlekamp_massey_decoder(received::Poly, nsym::Int)
 
     ### number of errors within the capacity of RS-Code
-    rawmsg = randpoly(155)
+    rawmsg = randpoly(Int, 155)
     nsym = 100
     errpos = unique!(rand(0:254, 50)) # error positions
     msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
@@ -140,7 +140,7 @@ end
     received.coeff[1 .+ errpos] .⊻= rand(1:255, length(errpos))
     sydpoly = syndrome_polynomial(received, nsym)
     Λx = erratalocator_polynomial(sydpoly, nsym)
-    errlocpoly = erratalocator_polynomial(errpos)
+    errlocpoly = erratalocator_polynomial(Int, errpos)
     @test Λx == errlocpoly
     @test berlekamp_massey_decoder(received, nsym) == msg
 
@@ -151,7 +151,7 @@ end
     @test berlekamp_massey_decoder(msg, nsym) == msg
 
     ### odd number of syndromes
-    rawmsg = randpoly(100)
+    rawmsg = randpoly(Int, 100)
     nsym = 155
     errpos = unique!(rand(0:254, 77)) # error positions
     msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
@@ -159,12 +159,12 @@ end
     received.coeff[1 .+ errpos] .⊻= rand(1:255, length(errpos))
     sydpoly = syndrome_polynomial(received, nsym)
     Λx = erratalocator_polynomial(sydpoly, nsym)
-    errlocpoly = erratalocator_polynomial(errpos)
+    errlocpoly = erratalocator_polynomial(Int, errpos)
     @test Λx == errlocpoly
     @test berlekamp_massey_decoder(received, nsym) == msg
 
     ### too much errors(detected)
-    rawmsg = randpoly(100)
+    rawmsg = randpoly(Int, 100)
     nsym = 155
     errpos = sample(0:254, 78; replace=false) # error positions
     msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
@@ -182,11 +182,69 @@ end
     errpos = [0, 1]
     received = copy(msg)
     received.coeff[1 .+ errpos] .⊻= [2, 3]
-    errlocpoly = erratalocator_polynomial(errpos)
+    errlocpoly = erratalocator_polynomial(Int, errpos)
     sydpoly = syndrome_polynomial(received, nsym)
     Λx = erratalocator_polynomial(sydpoly, nsym; check=true)
     @test !iszeropoly(errlocpoly + Λx)
-    @test Λx == erratalocator_polynomial([2])
+    @test Λx == erratalocator_polynomial(Int, [2])
+    @test !iszeropoly(berlekamp_massey_decoder(received, nsym) + msg)
+
+    # test for UInt8
+    rawmsg = randpoly(UInt8, 155)
+    nsym = 100
+    errpos = unique!(rand(0:254, 50)) # error positions
+    msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
+    received = copy(msg)
+    received.coeff[1 .+ errpos] .⊻= rand(0x1:0xff, length(errpos))
+    sydpoly = syndrome_polynomial(received, nsym)
+    Λx = erratalocator_polynomial(sydpoly, nsym)
+    errlocpoly = erratalocator_polynomial(UInt8, errpos)
+    @test Λx == errlocpoly
+    @test berlekamp_massey_decoder(received, nsym) == msg
+
+    ### no errors
+    sydpoly = syndrome_polynomial(msg, nsym)
+    Λx = erratalocator_polynomial(sydpoly, nsym)
+    @test Λx == unit(Poly{UInt8})
+    @test berlekamp_massey_decoder(msg, nsym) == msg
+
+    ### odd number of syndromes
+    rawmsg = randpoly(UInt8, 100)
+    nsym = 155
+    errpos = unique!(rand(0:254, 77)) # error positions
+    msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
+    received = copy(msg)
+    received.coeff[1 .+ errpos] .⊻= rand(0x1:0xff, length(errpos))
+    sydpoly = syndrome_polynomial(received, nsym)
+    Λx = erratalocator_polynomial(sydpoly, nsym)
+    errlocpoly = erratalocator_polynomial(UInt8, errpos)
+    @test Λx == errlocpoly
+    @test berlekamp_massey_decoder(received, nsym) == msg
+
+    ### too much errors(detected)
+    rawmsg = randpoly(UInt8, 100)
+    nsym = 155
+    errpos = sample(0x0:0xfe, 78; replace=false) # error positions
+    msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
+    received = copy(msg)
+    received.coeff[1 .+ errpos] .⊻= rand(0x1:0xff, length(errpos))
+    sydpoly = syndrome_polynomial(received, nsym)
+    @test_throws ReedSolomonError erratalocator_polynomial(sydpoly, nsym; check=true)
+    @test_throws ReedSolomonError berlekamp_massey_decoder(received, nsym)
+    
+    ### too much errors(undetected!)
+    ### [0] -encode> [0, 0, 0] -transfer> [2, 3, 0] -correct> [2, 3, 1] -decode> [1] 
+    rawmsg = Poly([0x0])
+    nsym = 2
+    msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
+    errpos = [0, 1]
+    received = copy(msg)
+    received.coeff[1 .+ errpos] .⊻= [2, 3]
+    errlocpoly = erratalocator_polynomial(UInt8, errpos)
+    sydpoly = syndrome_polynomial(received, nsym)
+    Λx = erratalocator_polynomial(sydpoly, nsym; check=true)
+    @test !iszeropoly(errlocpoly + Λx)
+    @test Λx == erratalocator_polynomial(UInt8, [2])
     @test !iszeropoly(berlekamp_massey_decoder(received, nsym) + msg)
 end
 
@@ -194,13 +252,13 @@ end
     ## -- The modified Forney syndromes is still debugging -- ##
 
     ### length of the received message is too long
-    rawmsg = randpoly(100)
+    rawmsg = randpoly(Int, 100)
     nsym = 156
     msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
     @test_throws DomainError berlekamp_massey_decoder(msg, nsym)
     
     ### number of erasures exceeds the capacity of RS-Code
-    rawmsg = randpoly(150)
+    rawmsg = randpoly(Int, 150)
     nsym = 50
     msg = rawmsg << nsym + geterrcode(rawmsg, nsym)
     erasures = sample(0:199, 51; replace=false)


### PR DESCRIPTION
Fix type-error caused by `erratalocator_polynomial(erasures::Vector)`.

Rewrite it by `erratalocator_polynomial(::Type{T}, erasures::Vector)` since `erasures` alone is not enough to tell the output type.